### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pom.yml
+++ b/.github/workflows/pom.yml
@@ -1,4 +1,6 @@
 name: POM generation
+permissions:
+  contents: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/KRR-Oxford/RSAComb/security/code-scanning/1](https://github.com/KRR-Oxford/RSAComb/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow. Since the workflow needs to commit changes to the repository, it requires `contents: write` permission. The best way to do this is to add the following block at the top level of the workflow (just after the `name` field), so it applies to all jobs unless overridden. No other permissions are required for this workflow, so only `contents: write` should be specified. This change does not affect the existing functionality but ensures the workflow follows the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
