### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -1,4 +1,6 @@
 name: Scala CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/KRR-Oxford/RSAComb/security/code-scanning/2](https://github.com/KRR-Oxford/RSAComb/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the least privilege required. Since the workflow appears to only check out code and run tests (no evidence of writing to the repository, creating issues, or making pull requests), the minimal required permission is `contents: read`. This can be set at the workflow level (top-level, after the `name` and before `on`), which will apply to all jobs unless overridden. No changes to the steps or job definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
